### PR TITLE
Fix GitHub Pages site deployment resulting in 404

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -1,26 +1,43 @@
-name: Deploy to GitHub Pages
+# Simple workflow for deploying static content to GitHub Pages
+name: Deploy static content to Pages
 
 on:
+  # Runs on pushes targeting the default branch
   push:
     branches: ["main"]
+
+  # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:
-  contents: write
+  contents: read
+  pages: write
+  id-token: write
 
+# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
+# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
 concurrency:
   group: "pages"
   cancel-in-progress: false
 
 jobs:
+  # Single deploy job since we're just deploying
   deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Deploy to gh-pages branch
-        uses: peaceiris/actions-gh-pages@v4
+      - name: Setup Pages
+        uses: actions/configure-pages@v4
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: .
-          publish_branch: gh-pages
+          # Upload entire repository
+          path: '.'
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+call.wecanuseai.com


### PR DESCRIPTION
The existing GitHub Actions workflow used the `peaceiris/actions-gh-pages@v4` action, which pushes the site to a `gh-pages` branch. This caused the site to be "not found" because GitHub Pages was likely configured to build directly rather than pulling from the `gh-pages` branch. 

This commit updates `.github/workflows/static.yml` to use modern GitHub actions to build the site as an artifact and deploy it directly, eliminating the need for a separate branch. The required OIDC permissions (`pages: write`, `id-token: write`) were also added to the workflow.

---
*PR created automatically by Jules for task [17815172388951279299](https://jules.google.com/task/17815172388951279299) started by @melbinjp*