### PR TITLE
Update Favicon

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,8 +15,20 @@
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet" />
     <title>call.wecanuseai.com</title>
     
-    <!-- Simple favicon -->
-    <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>ðŸ“ž</text></svg>">
+    <!-- Favicon from favicon.wecanuseai.com -->
+    <link rel="icon" type="image/x-icon" href="https://favicon.wecanuseai.com/favicon.ico">
+    <link rel="icon" type="image/png" sizes="16x16" href="https://favicon.wecanuseai.com/favicon-16x16.png">
+    <link rel="icon" type="image/png" sizes="32x32" href="https://favicon.wecanuseai.com/favicon-32x32.png">
+    <link rel="icon" type="image/png" sizes="48x48" href="https://favicon.wecanuseai.com/favicon-48x48.png">
+    <link rel="manifest" href="https://favicon.wecanuseai.com/manifest.webmanifest">
+    <link rel="apple-touch-icon" sizes="180x180" href="https://favicon.wecanuseai.com/apple-touch-icon-180x180.png">
+    <link rel="apple-touch-icon" sizes="152x152" href="https://favicon.wecanuseai.com/apple-touch-icon-152x152.png">
+    <link rel="apple-touch-icon" sizes="144x144" href="https://favicon.wecanuseai.com/apple-touch-icon-144x144.png">
+    <link rel="apple-touch-icon" sizes="120x120" href="https://favicon.wecanuseai.com/apple-touch-icon-120x120.png">
+    <link rel="apple-touch-icon" sizes="76x76" href="https://favicon.wecanuseai.com/apple-touch-icon-76x76.png">
+    <meta name="msapplication-TileColor" content="#007aff">
+    <meta name="msapplication-TileImage" content="https://favicon.wecanuseai.com/mstile-144x144.png">
+    <meta name="msapplication-config" content="https://favicon.wecanuseai.com/browserconfig.xml">
     
     <link rel="stylesheet" href="style.css">
     <script type="module">


### PR DESCRIPTION
Replaced the simple inline SVG favicon in `index.html` with a suite of `<link>` tags that import external icon assets (ICO, PNGs, Apple Touch icons, web manifest, etc.) from `favicon.wecanuseai.com`. Existing theme and app name tags were carefully preserved.

---
*PR created automatically by Jules for task [3861600830888360953](https://jules.google.com/task/3861600830888360953) started by @melbinjp*